### PR TITLE
Add "Delete All Chats" Feature to Account Settings

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -41,6 +41,7 @@ export const api = {
         create: `${API_BASE}/conversations`,
         search: (term: string, mode?: string) =>
             `${API_BASE}/conversations?search=${encodeURIComponent(term)}${mode ? `&mode=${mode}` : ''}`,
+        deleteAll: `${API_BASE}/conversations?all=true`,
     },
     messages: {
         getAllFromConversation: (conversationId: string) =>

--- a/src/lib/cache/cached-query.svelte.ts
+++ b/src/lib/cache/cached-query.svelte.ts
@@ -177,6 +177,7 @@ export const api = {
 		setPublic: { url: '/api/db/conversations', method: 'POST' } as QueryConfig,
 		togglePin: { url: '/api/db/conversations', method: 'POST' } as QueryConfig,
 		remove: { url: '/api/db/conversations', method: 'POST' } as QueryConfig,
+		deleteAll: { url: '/api/db/conversations?all=true', method: 'DELETE' } as QueryConfig,
 	},
 	messages: {
 		getAllFromConversation: { url: '/api/db/messages', method: 'GET' } as QueryConfig,

--- a/src/lib/db/queries/conversations.ts
+++ b/src/lib/db/queries/conversations.ts
@@ -219,6 +219,11 @@ export async function deleteConversation(conversationId: string, userId: string)
     await db.delete(conversations).where(eq(conversations.id, conversationId));
 }
 
+export async function deleteAllConversations(userId: string): Promise<void> {
+    // Messages will be cascade deleted due to foreign key constraint
+    await db.delete(conversations).where(eq(conversations.userId, userId));
+}
+
 export async function getConversationMessages(
     conversationId: string,
     userId: string

--- a/src/routes/account/+layout.svelte
+++ b/src/routes/account/+layout.svelte
@@ -59,9 +59,7 @@
 		await goto('/login');
 	}
 
-	const lastChat = useLastChat();
-
-	const backToChat = $derived(lastChat.current ? `/chat/${lastChat.current}` : '/chat');
+	const backToChat = '/chat';
 </script>
 
 <div class="container mx-auto max-w-[1200px] space-y-8 pt-6 pb-24">

--- a/src/routes/api/db/conversations/+server.ts
+++ b/src/routes/api/db/conversations/+server.ts
@@ -13,6 +13,7 @@ import {
     setConversationPublic,
     toggleConversationPin,
     deleteConversation,
+    deleteAllConversations,
     searchConversations,
 } from '$lib/db/queries';
 
@@ -107,10 +108,16 @@ export const POST: RequestHandler = async ({ request }) => {
     }
 };
 
-// DELETE - delete conversation
+// DELETE - delete conversation or all conversations
 export const DELETE: RequestHandler = async ({ request, url }) => {
     const userId = await getSessionUserId(request);
     const conversationId = url.searchParams.get('id');
+    const deleteAll = url.searchParams.get('all');
+
+    if (deleteAll === 'true') {
+        await deleteAllConversations(userId);
+        return json({ ok: true });
+    }
 
     if (!conversationId) {
         return error(400, 'Missing conversation id');


### PR DESCRIPTION
## Summary
Added a "Delete All Chats" feature to the Account Settings page that allows users to permanently delete all their conversations and messages in one action.

## Changes Made

### Backend

**1. `src/lib/db/queries/conversations.ts`**
- Added `deleteAllConversations(userId: string)` function to delete all conversations for a user
- Messages are automatically cascade deleted due to foreign key constraints

**2. `src/routes/api/db/conversations/+server.ts`**
- Modified DELETE handler to support bulk deletion via `?all=true` query parameter
- Validates user authentication before deletion

**3. `src/lib/cache/cached-query.svelte.ts`**
- Added `deleteAll` endpoint to the `api.conversations` object

### Frontend

**4. `src/routes/account/+page.svelte`**
- Added new collapsible "Delete All Chats" card section
- Implemented confirmation modal before deletion
- Added destructive-styled button with warning messaging
- After deletion, navigates user to `/chat`
- Invalidates both conversations and messages caches

**5. `src/routes/account/+layout.svelte`**
- Changed "Back to Chat" button to always navigate to `/chat` instead of the last visited conversation
- Prevents issues when returning to chat after deleting all chats

## Features
- Confirmation modal warns user that action cannot be undone
- Lists what will be deleted (all conversations, messages, associated data)
- Shows loading state during deletion
- Automatic cache invalidation for immediate UI update
- Navigation to clean chat interface after deletion
- No stale conversation URLs in navigation

## Testing
- Delete request properly authenticates user
- All conversations and messages are deleted from database
- Caches are properly invalidated
- Navigation works correctly
- No errors when clicking "Back to Chat" after deletion