### PR TITLE
feat: Add theme system with preset themes

### DIFF
--- a/drizzle/0016_elite_mastermind.sql
+++ b/drizzle/0016_elite_mastermind.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user_settings` ADD `theme` text;

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,1819 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8c8314ed-e21e-47eb-b75f-30bfffefd179",
+  "prevId": "ba08efe1-6212-4d99-8c85-9637a46d1a86",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_userId_user_id_fk": {
+          "name": "account_userId_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "assistants": {
+      "name": "assistants",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_default": {
+          "name": "is_default",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "default_model_id": {
+          "name": "default_model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_web_search_mode": {
+          "name": "default_web_search_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_web_search_provider": {
+          "name": "default_web_search_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "assistants_user_id_idx": {
+          "name": "assistants_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "assistants_user_id_user_id_fk": {
+          "name": "assistants_user_id_user_id_fk",
+          "tableFrom": "assistants",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "generating": {
+          "name": "generating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public": {
+          "name": "public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "branched_from": {
+          "name": "branched_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "assistant_id": {
+          "name": "assistant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "conversations_user_id_idx": {
+          "name": "conversations_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "conversations_user_id_user_id_fk": {
+          "name": "conversations_user_id_user_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_assistant_id_assistants_id_fk": {
+          "name": "conversations_assistant_id_assistants_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "assistants",
+          "columnsFrom": [
+            "assistant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_interactions": {
+      "name": "message_interactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "message_interactions_message_id_idx": {
+          "name": "message_interactions_message_id_idx",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "message_interactions_user_id_idx": {
+          "name": "message_interactions_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "message_interactions_action_idx": {
+          "name": "message_interactions_action_idx",
+          "columns": [
+            "action"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_interactions_message_id_messages_id_fk": {
+          "name": "message_interactions_message_id_messages_id_fk",
+          "tableFrom": "message_interactions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_interactions_user_id_user_id_fk": {
+          "name": "message_interactions_user_id_user_id_fk",
+          "tableFrom": "message_interactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_ratings": {
+      "name": "message_ratings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbs": {
+          "name": "thumbs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "categories": {
+          "name": "categories",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "message_ratings_message_id_idx": {
+          "name": "message_ratings_message_id_idx",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "message_ratings_user_id_idx": {
+          "name": "message_ratings_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_ratings_message_id_messages_id_fk": {
+          "name": "message_ratings_message_id_messages_id_fk",
+          "tableFrom": "message_ratings",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_ratings_user_id_user_id_fk": {
+          "name": "message_ratings_user_id_user_id_fk",
+          "tableFrom": "message_ratings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_html": {
+          "name": "content_html",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "images": {
+          "name": "images",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "documents": {
+          "name": "documents",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "generation_id": {
+          "name": "generation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "web_search_enabled": {
+          "name": "web_search_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "annotations": {
+          "name": "annotations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "messages_conversation_id_idx": {
+          "name": "messages_conversation_id_idx",
+          "columns": [
+            "conversation_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": [
+            "conversation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_performance_stats": {
+      "name": "model_performance_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_messages": {
+          "name": "total_messages",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_rating": {
+          "name": "avg_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbs_up_count": {
+          "name": "thumbs_up_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "thumbs_down_count": {
+          "name": "thumbs_down_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "regenerate_count": {
+          "name": "regenerate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "avg_response_time": {
+          "name": "avg_response_time",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avg_tokens": {
+          "name": "avg_tokens",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_cost": {
+          "name": "total_cost",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "accurate_count": {
+          "name": "accurate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "helpful_count": {
+          "name": "helpful_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "creative_count": {
+          "name": "creative_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "fast_count": {
+          "name": "fast_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "cost_effective_count": {
+          "name": "cost_effective_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "model_performance_user_id_idx": {
+          "name": "model_performance_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "model_performance_model_provider_idx": {
+          "name": "model_performance_model_provider_idx",
+          "columns": [
+            "model_id",
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "model_performance_user_model_provider_idx": {
+          "name": "model_performance_user_model_provider_idx",
+          "columns": [
+            "user_id",
+            "model_id",
+            "provider"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "model_performance_stats_user_id_user_id_fk": {
+          "name": "model_performance_stats_user_id_user_id_fk",
+          "tableFrom": "model_performance_stats",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "passkey": {
+      "name": "passkey",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "credentialID": {
+          "name": "credentialID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "aaguid": {
+          "name": "aaguid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webauthnUserID": {
+          "name": "webauthnUserID",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "counter": {
+          "name": "counter",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deviceType": {
+          "name": "deviceType",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "backedUp": {
+          "name": "backedUp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "passkey_userId_user_id_fk": {
+          "name": "passkey_userId_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "userId": {
+          "name": "userId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_userId_user_id_fk": {
+          "name": "session_userId_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "storage": {
+      "name": "storage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "storage_user_id_user_id_fk": {
+          "name": "storage_user_id_user_id_fk",
+          "tableFrom": "storage",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_enabled_models": {
+      "name": "user_enabled_models",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pinned": {
+          "name": "pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_enabled_models_user_id_idx": {
+          "name": "user_enabled_models_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_enabled_models_model_provider_idx": {
+          "name": "user_enabled_models_model_provider_idx",
+          "columns": [
+            "model_id",
+            "provider"
+          ],
+          "isUnique": false
+        },
+        "user_enabled_models_provider_user_idx": {
+          "name": "user_enabled_models_provider_user_idx",
+          "columns": [
+            "provider",
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_enabled_models_model_provider_user_idx": {
+          "name": "user_enabled_models_model_provider_user_idx",
+          "columns": [
+            "model_id",
+            "provider",
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_enabled_models_user_id_user_id_fk": {
+          "name": "user_enabled_models_user_id_user_id_fk",
+          "tableFrom": "user_enabled_models",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_keys": {
+      "name": "user_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_keys_user_id_idx": {
+          "name": "user_keys_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_keys_provider_user_idx": {
+          "name": "user_keys_provider_user_idx",
+          "columns": [
+            "provider",
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_keys_user_id_user_id_fk": {
+          "name": "user_keys_user_id_user_id_fk",
+          "tableFrom": "user_keys",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_memories": {
+      "name": "user_memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_memories_user_id_idx": {
+          "name": "user_memories_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_memories_user_id_user_id_fk": {
+          "name": "user_memories_user_id_user_id_fk",
+          "tableFrom": "user_memories",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_rules": {
+      "name": "user_rules",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "attach": {
+          "name": "attach",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rule": {
+          "name": "rule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_rules_user_id_idx": {
+          "name": "user_rules_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "user_rules_user_attach_idx": {
+          "name": "user_rules_user_attach_idx",
+          "columns": [
+            "user_id",
+            "attach"
+          ],
+          "isUnique": false
+        },
+        "user_rules_user_name_idx": {
+          "name": "user_rules_user_name_idx",
+          "columns": [
+            "user_id",
+            "name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_rules_user_id_user_id_fk": {
+          "name": "user_rules_user_id_user_id_fk",
+          "tableFrom": "user_rules",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_settings": {
+      "name": "user_settings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "privacy_mode": {
+          "name": "privacy_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "context_memory_enabled": {
+          "name": "context_memory_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "persistent_memory_enabled": {
+          "name": "persistent_memory_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "youtube_transcripts_enabled": {
+          "name": "youtube_transcripts_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "free_messages_used": {
+          "name": "free_messages_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "daily_messages_used": {
+          "name": "daily_messages_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_message_date": {
+          "name": "last_message_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "karakeep_url": {
+          "name": "karakeep_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "karakeep_api_key": {
+          "name": "karakeep_api_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "theme": {
+          "name": "theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_settings_user_id_idx": {
+          "name": "user_settings_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_settings_user_id_user_id_fk": {
+          "name": "user_settings_user_id_user_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1766508121757,
       "tag": "0015_exotic_fabian_cortez",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1766710048100,
+      "tag": "0016_elite_mastermind",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/components/account/ThemeSelector.svelte
+++ b/src/lib/components/account/ThemeSelector.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+	import { themes, getTheme, applyTheme, type Theme } from '$lib/themes/themes';
+	import { mutate } from '$lib/client/mutation.svelte';
+	import { api } from '$lib/cache/cached-query.svelte';
+	import { session } from '$lib/state/session.svelte';
+	import { ResultAsync } from 'neverthrow';
+	import CheckIcon from '~icons/lucide/check';
+
+	let { currentTheme = $bindable() }: { currentTheme: string | null | undefined } = $props();
+
+	let saving = $state(false);
+
+	async function selectTheme(themeId: string | null) {
+		if (!session.current?.user.id) return;
+
+		saving = true;
+		const theme = themeId ? getTheme(themeId) : null;
+
+		// Apply theme immediately for instant feedback
+		applyTheme(theme || null);
+
+		// Save to database
+		const res = await ResultAsync.fromPromise(
+			mutate(
+				api.user_settings.set.url,
+				{
+					action: 'update',
+					theme: themeId,
+				},
+				{
+					invalidatePatterns: [api.user_settings.get.url],
+				}
+			),
+			(e) => e
+		);
+
+		if (res.isOk()) {
+			currentTheme = themeId;
+		} else {
+			console.error('Failed to save theme:', res.error);
+			// Revert theme on error
+			const revertTheme = currentTheme ? getTheme(currentTheme) : null;
+			applyTheme(revertTheme || null);
+		}
+
+		saving = false;
+	}
+</script>
+
+<div class="flex flex-col gap-4">
+	<div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+		<!-- Auto (System Default) Option -->
+		<button
+			type="button"
+			onclick={() => selectTheme(null)}
+			disabled={saving}
+			class="border-input hover:bg-accent relative flex flex-col gap-2 rounded-lg border p-4 text-left transition-colors disabled:opacity-50 {currentTheme ===
+			null
+				? 'ring-ring ring-2'
+				: ''}"
+		>
+			<div class="flex items-center justify-between">
+				<span class="font-medium">Auto</span>
+				{#if currentTheme === null}
+					<CheckIcon class="text-primary h-5 w-5" />
+				{/if}
+			</div>
+			<p class="text-muted-foreground text-sm">System default light/dark theme</p>
+			<div class="mt-2 flex gap-2">
+				<div class="h-8 w-12 rounded border border-gray-300 bg-white"></div>
+				<div class="h-8 w-12 rounded border border-gray-700 bg-gray-900"></div>
+			</div>
+		</button>
+
+		<!-- Theme Options -->
+		{#each themes as theme (theme.id)}
+			<button
+				type="button"
+				onclick={() => selectTheme(theme.id)}
+				disabled={saving}
+				class="border-input hover:bg-accent relative flex flex-col gap-2 rounded-lg border p-4 text-left transition-colors disabled:opacity-50 {currentTheme ===
+				theme.id
+					? 'ring-ring ring-2'
+					: ''}"
+			>
+				<div class="flex items-center justify-between">
+					<span class="font-medium">{theme.name}</span>
+					{#if currentTheme === theme.id}
+						<CheckIcon class="text-primary h-5 w-5" />
+					{/if}
+				</div>
+				<p class="text-muted-foreground text-xs capitalize">{theme.mode} theme</p>
+				<div class="mt-2 flex gap-1">
+					<div
+						class="h-8 w-8 rounded border"
+						style="background-color: {theme.colors.background}; border-color: {theme.colors.border};"
+					></div>
+					<div
+						class="h-8 w-8 rounded border"
+						style="background-color: {theme.colors.primary}; border-color: {theme.colors.border};"
+					></div>
+					<div
+						class="h-8 w-8 rounded border"
+						style="background-color: {theme.colors.accent}; border-color: {theme.colors.border};"
+					></div>
+					<div
+						class="h-8 w-8 rounded border"
+						style="background-color: {theme.colors.sidebar}; border-color: {theme.colors.border};"
+					></div>
+				</div>
+			</button>
+		{/each}
+	</div>
+</div>

--- a/src/lib/db/queries/user-settings.ts
+++ b/src/lib/db/queries/user-settings.ts
@@ -26,6 +26,7 @@ export async function createUserSettings(
             freeMessagesUsed: data?.freeMessagesUsed ?? 0,
             karakeepUrl: data?.karakeepUrl ?? null,
             karakeepApiKey: data?.karakeepApiKey ?? null,
+            theme: data?.theme ?? null,
             createdAt: now,
             updatedAt: now,
         })

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -92,6 +92,7 @@ export const userSettings = sqliteTable(
         lastMessageDate: text('last_message_date'), // ISO date string (YYYY-MM-DD) for daily reset
         karakeepUrl: text('karakeep_url'),
         karakeepApiKey: text('karakeep_api_key'),
+        theme: text('theme'),
         createdAt: integer('created_at', { mode: 'timestamp' }).notNull(),
         updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull(),
     },

--- a/src/lib/state/settings.svelte.ts
+++ b/src/lib/state/settings.svelte.ts
@@ -5,4 +5,5 @@ export const settings = createPersistedObj('settings', {
 	webSearchMode: 'off' as 'off' | 'standard' | 'deep',
 	webSearchProvider: 'linkup' as 'linkup' | 'tavily' | 'exa' | 'kagi',
 	reasoningEffort: 'low' as 'low' | 'medium' | 'high',
+	theme: undefined as string | undefined,
 });

--- a/src/lib/themes/themes.ts
+++ b/src/lib/themes/themes.ts
@@ -1,0 +1,315 @@
+export interface ThemeColors {
+	// Base colors
+	background: string;
+	foreground: string;
+	card: string;
+	cardForeground: string;
+	popover: string;
+	popoverForeground: string;
+	
+	// Primary colors
+	primary: string;
+	primaryForeground: string;
+	heading: string;
+	
+	// Secondary colors
+	secondary: string;
+	secondaryForeground: string;
+	muted: string;
+	mutedForeground: string;
+	accent: string;
+	accentForeground: string;
+	
+	// Destructive
+	destructive: string;
+	destructiveForeground: string;
+	
+	// Borders & inputs
+	border: string;
+	input: string;
+	ring: string;
+	
+	// Sidebar
+	sidebar: string;
+	sidebarForeground: string;
+	sidebarPrimary: string;
+	sidebarPrimaryForeground: string;
+	sidebarAccent: string;
+	sidebarAccentForeground: string;
+	sidebarBorder: string;
+	sidebarRing: string;
+}
+
+export interface Theme {
+	id: string;
+	name: string;
+	mode: 'light' | 'dark';
+	colors: ThemeColors;
+}
+
+export const themes: Theme[] = [
+	// Dracula
+	{
+		id: 'dracula',
+		name: 'Dracula',
+		mode: 'dark',
+		colors: {
+			background: '#282a36',
+			foreground: '#f8f8f2',
+			card: '#282a36',
+			cardForeground: '#f8f8f2',
+			popover: '#21222c',
+			popoverForeground: '#f8f8f2',
+			primary: '#bd93f9',
+			primaryForeground: '#282a36',
+			heading: '#f8f8f2',
+			secondary: '#44475a',
+			secondaryForeground: '#f8f8f2',
+			muted: '#44475a',
+			mutedForeground: '#6272a4',
+			accent: '#44475a',
+			accentForeground: '#f8f8f2',
+			destructive: '#ff5555',
+			destructiveForeground: '#f8f8f2',
+			border: '#44475a',
+			input: '#44475a',
+			ring: '#bd93f9',
+			sidebar: '#191a21',
+			sidebarForeground: '#6272a4',
+			sidebarPrimary: '#bd93f9',
+			sidebarPrimaryForeground: '#282a36',
+			sidebarAccent: '#21222c',
+			sidebarAccentForeground: '#f8f8f2',
+			sidebarBorder: '#21222c',
+			sidebarRing: '#bd93f9',
+		},
+	},
+	// Catppuccin Latte (Light)
+	{
+		id: 'catppuccin-latte',
+		name: 'Catppuccin Latte',
+		mode: 'light',
+		colors: {
+			background: '#eff1f5',
+			foreground: '#4c4f69',
+			card: '#e6e9ef',
+			cardForeground: '#4c4f69',
+			popover: '#ffffff',
+			popoverForeground: '#4c4f69',
+			primary: '#8839ef',
+			primaryForeground: '#eff1f5',
+			heading: '#8839ef',
+			secondary: '#ccd0da',
+			secondaryForeground: '#5c5f77',
+			muted: '#e6e9ef',
+			mutedForeground: '#6c6f85',
+			accent: '#ccd0da',
+			accentForeground: '#5c5f77',
+			destructive: '#d20f39',
+			destructiveForeground: '#eff1f5',
+			border: '#ccd0da',
+			input: '#e6e9ef',
+			ring: '#8839ef',
+			sidebar: '#dce0e8',
+			sidebarForeground: '#5c5f77',
+			sidebarPrimary: '#8839ef',
+			sidebarPrimaryForeground: '#eff1f5',
+			sidebarAccent: '#ccd0da',
+			sidebarAccentForeground: '#5c5f77',
+			sidebarBorder: '#bcc0cc',
+			sidebarRing: '#8839ef',
+		},
+	},
+	// Catppuccin Mocha (Dark)
+	{
+		id: 'catppuccin-mocha',
+		name: 'Catppuccin Mocha',
+		mode: 'dark',
+		colors: {
+			background: '#1e1e2e',
+			foreground: '#cdd6f4',
+			card: '#1e1e2e',
+			cardForeground: '#cdd6f4',
+			popover: '#181825',
+			popoverForeground: '#cdd6f4',
+			primary: '#cba6f7',
+			primaryForeground: '#1e1e2e',
+			heading: '#cdd6f4',
+			secondary: '#45475a',
+			secondaryForeground: '#cdd6f4',
+			muted: '#313244',
+			mutedForeground: '#a6adc8',
+			accent: '#45475a',
+			accentForeground: '#cdd6f4',
+			destructive: '#f38ba8',
+			destructiveForeground: '#1e1e2e',
+			border: '#45475a',
+			input: '#313244',
+			ring: '#cba6f7',
+			sidebar: '#11111b',
+			sidebarForeground: '#bac2de',
+			sidebarPrimary: '#cba6f7',
+			sidebarPrimaryForeground: '#1e1e2e',
+			sidebarAccent: '#181825',
+			sidebarAccentForeground: '#cdd6f4',
+			sidebarBorder: '#181825',
+			sidebarRing: '#cba6f7',
+		},
+	},
+	// Nord (works well in both modes, but we'll define it as dark)
+	{
+		id: 'nord',
+		name: 'Nord',
+		mode: 'dark',
+		colors: {
+			background: '#2e3440',
+			foreground: '#eceff4',
+			card: '#2e3440',
+			cardForeground: '#eceff4',
+			popover: '#3b4252',
+			popoverForeground: '#eceff4',
+			primary: '#88c0d0',
+			primaryForeground: '#2e3440',
+			heading: '#eceff4',
+			secondary: '#4c566a',
+			secondaryForeground: '#eceff4',
+			muted: '#3b4252',
+			mutedForeground: '#d8dee9',
+			accent: '#4c566a',
+			accentForeground: '#eceff4',
+			destructive: '#bf616a',
+			destructiveForeground: '#eceff4',
+			border: '#4c566a',
+			input: '#3b4252',
+			ring: '#88c0d0',
+			sidebar: '#242933',
+			sidebarForeground: '#d8dee9',
+			sidebarPrimary: '#88c0d0',
+			sidebarPrimaryForeground: '#2e3440',
+			sidebarAccent: '#3b4252',
+			sidebarAccentForeground: '#eceff4',
+			sidebarBorder: '#3b4252',
+			sidebarRing: '#88c0d0',
+		},
+	},
+	// Tokyo Night
+	{
+		id: 'tokyo-night',
+		name: 'Tokyo Night',
+		mode: 'dark',
+		colors: {
+			background: '#1a1b26',
+			foreground: '#c0caf5',
+			card: '#1a1b26',
+			cardForeground: '#c0caf5',
+			popover: '#16161e',
+			popoverForeground: '#c0caf5',
+			primary: '#7aa2f7',
+			primaryForeground: '#1a1b26',
+			heading: '#c0caf5',
+			secondary: '#414868',
+			secondaryForeground: '#c0caf5',
+			muted: '#24283b',
+			mutedForeground: '#9aa5ce',
+			accent: '#414868',
+			accentForeground: '#c0caf5',
+			destructive: '#f7768e',
+			destructiveForeground: '#c0caf5',
+			border: '#414868',
+			input: '#24283b',
+			ring: '#7aa2f7',
+			sidebar: '#16161e',
+			sidebarForeground: '#9aa5ce',
+			sidebarPrimary: '#7aa2f7',
+			sidebarPrimaryForeground: '#1a1b26',
+			sidebarAccent: '#1f2335',
+			sidebarAccentForeground: '#c0caf5',
+			sidebarBorder: '#1f2335',
+			sidebarRing: '#7aa2f7',
+		},
+	},
+];
+
+export function getTheme(themeId: string): Theme | undefined {
+	return themes.find((t) => t.id === themeId);
+}
+
+export function applyTheme(theme: Theme | null) {
+	if (typeof document === 'undefined') return;
+
+	const root = document.documentElement;
+
+	if (!theme) {
+		// Reset to default theme - remove all custom properties
+		const props = [
+			'--background',
+			'--foreground',
+			'--card',
+			'--card-foreground',
+			'--popover',
+			'--popover-foreground',
+			'--primary',
+			'--primary-foreground',
+			'--heading',
+			'--secondary',
+			'--secondary-foreground',
+			'--muted',
+			'--muted-foreground',
+			'--accent',
+			'--accent-foreground',
+			'--destructive',
+			'--destructive-foreground',
+			'--border',
+			'--input',
+			'--ring',
+			'--sidebar',
+			'--sidebar-foreground',
+			'--sidebar-primary',
+			'--sidebar-primary-foreground',
+			'--sidebar-accent',
+			'--sidebar-accent-foreground',
+			'--sidebar-border',
+			'--sidebar-ring',
+		];
+		props.forEach((prop) => root.style.removeProperty(prop));
+		return;
+	}
+
+	// Apply theme colors
+	const { colors } = theme;
+	root.style.setProperty('--background', colors.background);
+	root.style.setProperty('--foreground', colors.foreground);
+	root.style.setProperty('--card', colors.card);
+	root.style.setProperty('--card-foreground', colors.cardForeground);
+	root.style.setProperty('--popover', colors.popover);
+	root.style.setProperty('--popover-foreground', colors.popoverForeground);
+	root.style.setProperty('--primary', colors.primary);
+	root.style.setProperty('--primary-foreground', colors.primaryForeground);
+	root.style.setProperty('--heading', colors.heading);
+	root.style.setProperty('--secondary', colors.secondary);
+	root.style.setProperty('--secondary-foreground', colors.secondaryForeground);
+	root.style.setProperty('--muted', colors.muted);
+	root.style.setProperty('--muted-foreground', colors.mutedForeground);
+	root.style.setProperty('--accent', colors.accent);
+	root.style.setProperty('--accent-foreground', colors.accentForeground);
+	root.style.setProperty('--destructive', colors.destructive);
+	root.style.setProperty('--destructive-foreground', colors.destructiveForeground);
+	root.style.setProperty('--border', colors.border);
+	root.style.setProperty('--input', colors.input);
+	root.style.setProperty('--ring', colors.ring);
+	root.style.setProperty('--sidebar', colors.sidebar);
+	root.style.setProperty('--sidebar-foreground', colors.sidebarForeground);
+	root.style.setProperty('--sidebar-primary', colors.sidebarPrimary);
+	root.style.setProperty('--sidebar-primary-foreground', colors.sidebarPrimaryForeground);
+	root.style.setProperty('--sidebar-accent', colors.sidebarAccent);
+	root.style.setProperty('--sidebar-accent-foreground', colors.sidebarAccentForeground);
+	root.style.setProperty('--sidebar-border', colors.sidebarBorder);
+	root.style.setProperty('--sidebar-ring', colors.sidebarRing);
+
+	// Also update the class for mode-watcher compatibility
+	if (theme.mode === 'dark') {
+		root.classList.add('dark');
+	} else {
+		root.classList.remove('dark');
+	}
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,11 +9,37 @@
 	import { MetaTags } from 'svelte-meta-tags';
 	import { page } from '$app/state';
 	import { setupLastChat } from '$lib/state/last-chat.svelte';
+	import { getTheme, applyTheme } from '$lib/themes/themes';
+	import { session } from '$lib/state/session.svelte';
+	import { onMount } from 'svelte';
 
 	let { children } = $props();
 
 	const lastChat = setupLastChat();
 	models.init();
+
+	// Apply saved theme on mount
+	onMount(async () => {
+		if (browser && session.current?.user.id) {
+			try {
+				const response = await fetch('/api/db/user-settings', {
+					method: 'GET',
+					credentials: 'include',
+				});
+				if (response.ok) {
+					const settings = await response.json();
+					if (settings.theme) {
+						const theme = getTheme(settings.theme);
+						if (theme) {
+							applyTheme(theme);
+						}
+					}
+				}
+			} catch (error) {
+				console.error('Failed to load theme:', error);
+			}
+		}
+	});
 
 	$effect(() => {
 		if (page.url.pathname.startsWith('/chat')) {

--- a/src/routes/account/+page.svelte
+++ b/src/routes/account/+page.svelte
@@ -286,7 +286,7 @@
 				</div>
 				<Switch bind:value={() => youtubeTranscriptsEnabled, toggleYoutubeTranscripts} />
 			</div>
-		</CardContent>
+	</CardContent>
 	</Card>
 
 	<!-- Karakeep Integration Section (Collapsible) -->

--- a/src/routes/account/customization/+page.svelte
+++ b/src/routes/account/customization/+page.svelte
@@ -12,6 +12,15 @@
 	import type { Doc } from '$lib/db/types';
 	import { Input } from '$lib/components/ui/input';
 	import Rule from './rule.svelte';
+	import ThemeSelector from '$lib/components/account/ThemeSelector.svelte';
+	import type { UserSettings } from '$lib/api';
+	import {
+		Root as Card,
+		Content as CardContent,
+		Description as CardDescription,
+		Header as CardHeader,
+		Title as CardTitle,
+	} from '$lib/components/ui/card';
 
 	const newRuleCollapsible = new Collapsible({
 		open: false,
@@ -20,6 +29,13 @@
 	let creatingRule = $state(false);
 
 	const userRulesQuery: QueryResult<Doc<'user_rules'>[]> = useCachedQuery(api.user_rules.all, {});
+	const settings = useCachedQuery<UserSettings>(api.user_settings.get, {});
+
+	let currentTheme = $state(settings.data?.theme ?? null);
+
+	$effect(() => {
+		if (settings.data?.theme !== undefined) currentTheme = settings.data.theme;
+	});
 
 	async function submitNewRule(e: SubmitEvent) {
 		e.preventDefault();
@@ -57,6 +73,16 @@
 <h2 class="text-muted-foreground mt-2 text-sm">Customize your experience with nanochat.</h2>
 
 <div class="mt-8 flex flex-col gap-4">
+	<!-- Theme Section -->
+	<Card>
+		<CardHeader>
+			<CardTitle>Theme</CardTitle>
+			<CardDescription>Choose a color theme for the application.</CardDescription>
+		</CardHeader>
+		<CardContent>
+			<ThemeSelector bind:currentTheme />
+		</CardContent>
+	</Card>
 	<div class="flex place-items-center justify-between">
 		<h3 class="text-xl font-bold">Rules</h3>
 		<Button

--- a/src/routes/api/db/user-settings/+server.ts
+++ b/src/routes/api/db/user-settings/+server.ts
@@ -35,10 +35,11 @@ export const POST: RequestHandler = async ({ request }) => {
 				privacyMode: body.privacyMode,
 				contextMemoryEnabled: body.contextMemoryEnabled,
 				persistentMemoryEnabled: body.persistentMemoryEnabled,
-				youtubeTranscriptsEnabled: body.youtubeTranscriptsEnabled,
-				karakeepUrl: body.karakeepUrl,
-				karakeepApiKey: body.karakeepApiKey,
-			});
+                youtubeTranscriptsEnabled: body.youtubeTranscriptsEnabled,
+                karakeepUrl: body.karakeepUrl,
+                karakeepApiKey: body.karakeepApiKey,
+                theme: body.theme,
+            });
 			return json(settings);
 		}
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,10 @@ export default defineConfig({
 	server: {
 		allowedHosts: isDev ? true : undefined,
 	},
+	ssr: {
+		noExternal: ['bun:sqlite'],
+		external: [],
+	},
 	test: {
 		projects: [
 			{


### PR DESCRIPTION
## Overview
This PR adds a comprehensive theme system to the application with preset themes including Dracula, Catppuccin (Latte & Mocha), Nord, and Tokyo Night.

## Changes
- **Database Schema**: Added \`theme\` field to \`userSettings\` table
- **Theme System** (\`src/lib/themes/themes.ts\`): Created theme type definitions and 5 preset themes
- **ThemeSelector Component**: Visual theme selector with color previews
- **Settings Integration**: Added Themes section to Customization settings page
- **Auto-apply**: Themes are automatically applied on app load based on user preference
- **Migration**: Included database migration (\`drizzle/0016_elite_mastermind.sql\`)

## Themes Included
1. **Dracula** (dark) - Purple accents with dark backgrounds
2. **Catppuccin Latte** (light) - Soft pastel light theme
3. **Catppuccin Mocha** (dark) - Soft pastel dark theme
4. **Nord** (dark) - Cool blue/gray Arctic-inspired palette
5. **Tokyo Night** (dark) - Purple/blue night theme

## Testing
- [x] Themes apply correctly when selected
- [x] Theme preference persists across sessions
- [x] Database migration works correctly
- [x] Works with existing light/dark mode toggle

## Screenshots
The theme selector shows visual previews with color swatches for each theme, making it easy for users to choose their preferred color scheme.