### PR TITLE
Fix sidebar title update delay

### DIFF
--- a/src/routes/chat/+layout.svelte
+++ b/src/routes/chat/+layout.svelte
@@ -140,10 +140,9 @@
 			wasGeneratingInLayout = true;
 		} else if (wasGeneratingInLayout) {
 			wasGeneratingInLayout = false;
-			// Title is generated asynchronously after response completes
-			// Trigger multiple delayed refreshes to catch the title update
-			setTimeout(() => invalidateQueryPattern(api.conversations.get.url), 2000);
-			setTimeout(() => invalidateQueryPattern(api.conversations.get.url), 5000);
+			// Title generation now happens while generating=true, so the existing
+			// polling mechanism in app-sidebar.svelte will catch the update
+			// No additional refreshes needed here
 		}
 	});
 


### PR DESCRIPTION
## Problem
Whenever a title is generated, sometimes the sidebar does not update until you click off and back on to that chat, or even refresh the page. This happens because title generation occurs asynchronously after the `generating` flag is set to false, causing the UI polling to stop before the title update is complete.
## Solution
Extended the `generating` flag to remain true until title generation completes. This leverages the existing polling mechanisms in the sidebar to automatically catch the title update without requiring manual refreshes.
## Changes
1. Moved title generation to occur before setting `generating: false` in the API handler (`src/routes/api/generate-message/+server.ts`)
2. Removed redundant delayed refreshes in the chat layout component (`src/routes/chat/+layout.svelte`)
3. Added explanatory comments about the new flow
## Testing
Verified that:
- Sidebar updates automatically when title generation completes
- Spinner shows during both response generation and title generation
- Error handling remains intact for title generation failures
This fix ensures the sidebar reflects the correct title without any steps from the end user, improving the overall user experience.