### PR TITLE
Fix assistant model dropdown not showing models

### DIFF
--- a/src/routes/account/assistants/+page.svelte
+++ b/src/routes/account/assistants/+page.svelte
@@ -26,7 +26,7 @@
 		{}
 	);
 	const enabledModels = $derived(
-		(enabledModelsQuery.data ?? []) as { id: string; modelId: string }[]
+		Object.values(enabledModelsQuery.data ?? {}) as { id: string; modelId: string }[]
 	);
 
 	const assistantsQuery = useCachedQuery<Assistant[]>(api.assistants.list, {


### PR DESCRIPTION
## Summary
Fixed the issue where models were not showing in the assistant editing dropdown. The problem was caused by incorrect handling of the enabled models data structure.
## Technical Details
The `getEnabledModels()` function returns data as a `Record<string, UserEnabledModel>` (object), but the code in `src/routes/account/assistants/+page.svelte` was treating it as an array. 
Changed line 29 from:
```typescript
const enabledModels = $derived(
    (enabledModelsQuery.data ?? []) as { id: string; modelId: string }[]
);
```
To:
```typescript
const enabledModels = $derived(
    Object.values(enabledModelsQuery.data ?? {}) as { id: string; modelId: string }[]
);
```
This matches the pattern already used in the model picker component (`src/lib/components/model-picker/model-picker.svelte` line 44).
## Testing
Verified that models now appear correctly in the assistant editing dropdown when creating or editing an assistant.